### PR TITLE
Added sanity check when creating Panel of Normals

### DIFF
--- a/exomedepth/README.md
+++ b/exomedepth/README.md
@@ -1,13 +1,3 @@
----
-title: "ExomeDepth CNV pipeline"
-author: "David Brawand <dbrawand@nhs.net>"
-date: "2021/02/15"
-output:
-  pdf_document:
-    toc: true
-    highlight: zenburn
----
-
 # SEGLH ExomeDepth pipeline
 
 ## input files

--- a/exomedepth/readCount.R
+++ b/exomedepth/readCount.R
@@ -22,6 +22,7 @@ normalprefix<-'NORMAL'
 cmp.cols<-3
 sex<-regex('_[MF]_')
 min.refs<-2
+mincov.pon<-100
 #
 # READ ARGS
 #
@@ -144,10 +145,18 @@ if (length(normals)>0) {
 #
 if (length(testsamplenames)==0) {
     message('Creating Panel of Normals (PoN)...')
+	# remove all samples from PoN that do not match coverage requirement
+	bad.normals<-names(which(apply(counts[,bams], 2, min)<mincov.pon))
+	if (length(bad.normals)>0) {
+		message("Removing normals that have insufficient ROI coverage")
+		print(bad.normals)
+		counts<-counts[,-which(colnames(counts) %in% bad.normals)],
+	}
     # save normal counts
     save(list=c("refsamplenames",  # supplied normals
                 "counts"),         # normal counts
          file = args[1])
+
 } else {
     message('Building reference sets...')
     # Calculate RPKM

--- a/exomedepth/readCount.R
+++ b/exomedepth/readCount.R
@@ -150,7 +150,7 @@ if (length(testsamplenames)==0) {
 	if (length(bad.normals)>0) {
 		message("Removing normals that have insufficient ROI coverage")
 		print(bad.normals)
-		counts<-counts[,-which(colnames(counts) %in% bad.normals)],
+		counts<-counts[,-which(colnames(counts) %in% bad.normals)]
 	}
     # save normal counts
     save(list=c("refsamplenames",  # supplied normals


### PR DESCRIPTION
BAMs which do not show min 100x coverage in all candidate regions are automatically excluded. This prevent PoN creation from BAMs which miss certain capture regions (eg. old version of capture kit)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/seglh-cnv/3)
<!-- Reviewable:end -->
