### PR TITLE
change mincov to 0

### DIFF
--- a/exomedepth/README.md
+++ b/exomedepth/README.md
@@ -87,8 +87,6 @@ Exomedepth, as default, runs with intra-batch normalisation (normals are picked 
 
 To run exomedepth in PoN mode, supply normal BAMs to the readCount step as any other BAM file, but ensure their name is prefixed with _NORMAL_. This will automatically switch to PoN mode. The used normalisation mode is also indicated on the PDF reports, alongside the picked normal samples.
 
-Any normals that have low coverage (below 100X) in _any_ of the supplied target regions will automatically be dropped as a safety measure.
-
 If a Panel of Normals is supplied, the `readCount.R` script will pick reference sets for both, the PoN and the supplied batch, under the condition that there are at least 3 reference samples to choose from.
 
 To avoid recounting reads for the normal samples, a `readCount.RData` file from a previous run can be supplied and the normals contained in this run will be merged into the counts table. Normal BAMs supplied will not be recounted if they are in the RData file.

--- a/exomedepth/readCount.R
+++ b/exomedepth/readCount.R
@@ -22,7 +22,7 @@ normalprefix<-'NORMAL'
 cmp.cols<-3
 sex<-regex('_[MF]_')
 min.refs<-2
-mincov.pon<-100
+mincov.pon<-0
 #
 # READ ARGS
 #


### PR DESCRIPTION
minimum coverage for reference samples used to create the panel of normals changed back to 0 from 100. 
Setting the limit to 100 caused issues when generating panel of normals (too many regions with less than 100x coverage leading to majority of the samples being excluded)