### PR TITLE
changes to filter the genes/regions that are not present in CNV bed

### DIFF
--- a/exomedepth/Dockerfile
+++ b/exomedepth/Dockerfile
@@ -64,13 +64,16 @@ RUN Rscript -e "install.packages('optparse')" && \
 	Rscript -e "install.packages('kableExtra')" && \
 	Rscript -e "install.packages('tinytex')" && \
 	Rscript -e "install.packages('xtable')" && \
-	Rscript -e "install.packages('moments')"
+	Rscript -e "install.packages('moments')" && \
+	Rscript -e "install.packages('tidyr')" 
 
 # install ED from source as CRAN rejected ED (10/2022) v1.1.16
 # CRAN reinstated ED (11/2020) v1.1.16
 #RUN Rscript -e "install.packages('devtools')" && \
 #    Rscript -e "require(devtools);install_github('vplagnol/ExomeDepth', ref='7f6f8621801d1eb46880f88c4f71bb7c31680c73')"
-
+# ExomeDepth package is no longer available on CRAN so need to install from github, use ref for v1.1.16 which is existing version
+RUN Rscript -e "install.packages('remotes'); remotes::install_github('vplagnol/ExomeDepth', ref='7f6f8621801d1eb46880f88c4f71bb7c31680c73')" 
+RUN R -e "installed_packages <- installed.packages(); print(installed_packages[, c(1, 3)])"
 # add exomedepth scripts and report template
 ADD readCount.R /root
 ADD ed2vcf.R /root

--- a/exomedepth/Makefile
+++ b/exomedepth/Makefile
@@ -3,26 +3,24 @@ BUILD   := $(shell git log -1 --pretty=%h)
 # define image names
 APP      := exomedepth
 REGISTRY := seglh
+DIR := $(shell pwd)
 
 # build tags
 IMG           := $(REGISTRY)/$(APP)
 IMG_VERSIONED := $(IMG):$(BUILD)
-IMG_LATEST    := $(IMG):latest
 IMG_DEV       := $(IMG):dev
 
 .PHONY: push build version cleanbuild
 
 push: build
 	docker push $(IMG_VERSIONED)
-	docker push $(IMG_LATEST)
 
 build: version
 	docker buildx build --platform linux/amd64 -t $(IMG_VERSIONED) . || docker build -t $(IMG_VERSIONED) .
-	docker tag $(IMG_VERSIONED) $(IMG_LATEST)
+	docker save $(IMG_VERSIONED) | gzip > $(DIR)/$(REGISTRY)-$(APP):$(BUILD).tar.gz
 
 cleanbuild: version
 	docker buildx build --platform linux/amd64 --no-cache -t $(IMG_VERSIONED) . || docker build -t $(IMG_VERSIONED) .
-	docker tag $(IMG_VERSIONED) $(IMG_LATEST)
 
 devbuild: version
 	docker build -t $(IMG_DEV) .

--- a/exomedepth/exomeDepth.Rnw
+++ b/exomedepth/exomeDepth.Rnw
@@ -545,7 +545,7 @@ for (rs in rev(names(results))) {
           } else {
             match_col <- append(match_col, crs)
             cnv_merged<-cnvs %>% left_join(results[[crs]]@CNV.calls,
-              by=c('start.p','end.p'))
+              by=c('start','end'))
             cnv_match[[crs]]<-ifelse(!is.na(cnv_merged$chromosome.y),"\\checkmark","")
           } 
         }


### PR DESCRIPTION
This is to filter out the genes and regions (in ED report) that are not present in CNV bed files.
Current Exomedepth docker calculates CNV based on the readcount bed file and the ED report shows all those calculated regions even some gene/regions are not in the CNV bed. This can lead to incidental findings; therefore, it is good to filter out with bedfile after CNV calculation. 

Updates
- added a piece of code to map CNV bed and Readcount bed and get the exon number info from Readcount bed since CNV bed does not have exon number info
- added a piece of code to filter out regions using CNV bed 
- filtering out was done after CNV calculation therefore calculation concept remains the same 
- updated Dockerfile and Makefile to add required R packages