### PR TITLE
tidy Makefile

### DIFF
--- a/exomedepth/Makefile
+++ b/exomedepth/Makefile
@@ -1,4 +1,4 @@
-BUILD   := $(shell git log -1 --pretty=%h)
+VERSION  := $(shell git describe --tags --always --dirty)
 
 # define image names
 APP      := exomedepth
@@ -6,26 +6,15 @@ REGISTRY := seglh
 
 # build tags
 IMG           := $(REGISTRY)/$(APP)
-IMG_VERSIONED := $(IMG):$(BUILD)
-IMG_LATEST    := $(IMG):latest
-IMG_DEV       := $(IMG):dev
-
-.PHONY: push build version cleanbuild
+IMG_VERSIONED := $(IMG):$(VERSION)
+.PHONY: push build
 
 push: build
 	docker push $(IMG_VERSIONED)
-	docker push $(IMG_LATEST)
 
 build: version
 	docker buildx build --platform linux/amd64 -t $(IMG_VERSIONED) . || docker build -t $(IMG_VERSIONED) .
-	docker tag $(IMG_VERSIONED) $(IMG_LATEST)
-
-cleanbuild: version
-	docker buildx build --platform linux/amd64 --no-cache -t $(IMG_VERSIONED) . || docker build -t $(IMG_VERSIONED) .
-	docker tag $(IMG_VERSIONED) $(IMG_LATEST)
-
-devbuild: version
-	docker build -t $(IMG_DEV) .
+	docker save $(IMG_VERSIONED) | gzip > $(REGISTRY)_$(APP)_$(VERSION).tar.gz
 
 version:
-	echo $(BUILD) > VERSION
+	echo $(VERSION) > VERSION


### PR DESCRIPTION
Makefile was tidied

- not to push `latest` tag to docker repo
- to use the github released version for the docker image tag
- to remove unused part such as cleanbuild and dev build 